### PR TITLE
fix: Correct permissions and add artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build_and_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -21,6 +23,13 @@ jobs:
               makeindex main
               pdflatex main.tex
           "
+
+      - name: Upload PDF as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-pdf
+          path: main.pdf
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This commit fixes the GitHub Actions workflow.

- Adds `permissions: contents: write` to the job to allow the creation of GitHub Releases, fixing the 403 error.
- Adds a new step to upload the generated PDF as a workflow artifact for easier access.