### PR TITLE
refactor: Split workflow into build and release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,11 @@
 name: Build and Release PDF
 
 on:
-  push:
-    branches:
-      - main
+  push
 
 jobs:
-  build_and_release:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -29,6 +25,18 @@ jobs:
         with:
           name: main-pdf
           path: main.pdf
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - name: Download PDF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: main-pdf
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
This commit refactors the GitHub Actions workflow to separate the build and release processes.

- The workflow now triggers on every push to any branch.
- A `build` job runs on every commit, builds the PDF, and uploads it as a workflow artifact.
- A `release` job is now conditional and runs only on pushes to the `main` branch. It downloads the artifact from the `build` job and creates the GitHub Release.

This change allows for artifact generation on all commits while restricting releases to the main branch.