### PR TITLE
Fix LaTeX build error in ch-mibot-eval.tex

### DIFF
--- a/ch-mibot-eval.tex
+++ b/ch-mibot-eval.tex
@@ -392,7 +392,7 @@ The system assigns behavioural codes to each utterance: counsellor utterances ar
     
     \item \textbf{\margindex[AutoMISC]{Reflection-to-Question Ratio (R:Q)}Reflection-to-Question Ratio (R:Q):} The ratio of counsellor utterances labelled as reflection (R) to those labelled as question (Q). This metric assesses the balance between reflective listening and questioning. Values between 1 and 2 are considered indicative of proficiency \citep{moyers2016}.
 
-    \item \textbf{\margindex[AutoMISC]{Percentage Change Talk (%CT)}Percentage Change Talk (\%CT):} The proportion of client utterances expressing motivation toward behaviour change. Higher values are associated with improved behavioural outcomes \citep{apodaca2009}.
+    \item \textbf{\margindex[AutoMISC]{Percentage Change Talk (\%CT)}Percentage Change Talk (\%CT):} The proportion of client utterances expressing motivation toward behaviour change. Higher values are associated with improved behavioural outcomes \citep{apodaca2009}.
 \end{itemize}
 
 \subsection{Contextualizing AutoMISC metrics with the HLQC Dataset}


### PR DESCRIPTION
An unescaped '%' character in the argument of a `\margindex` command was causing a "runaway argument" error during LaTeX compilation. This change escapes the percent sign to resolve the issue.