### PR TITLE
build: Use biblatex instead of bibtex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           docker run --rm -v "$(pwd)":/workspace -w /workspace texlive/texlive:TL2024-historic bash -c "
               pdflatex main.tex
-              bibtex main
+              biber main
               pdflatex main.tex
               makeindex main
               pdflatex main.tex

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ if [ "$USE_DOCKER" = true ]; then
     echo "Running LaTeX compilation with Docker ${TEXLIVE_VERSION}..."
     docker run --rm -v "$(pwd)":/workspace -w /workspace $TEXLIVE_VERSION bash -c "
         pdflatex ${MAIN_TEX_FILE}.tex
-        bibtex ${MAIN_TEX_FILE}
+        biber ${MAIN_TEX_FILE}
         pdflatex ${MAIN_TEX_FILE}.tex
         makeindex ${MAIN_TEX_FILE}
         pdflatex ${MAIN_TEX_FILE}.tex
@@ -63,7 +63,7 @@ if [ "$USE_DOCKER" = true ]; then
 else
     echo "Running LaTeX compilation locally..."
     pdflatex ${MAIN_TEX_FILE}.tex
-    bibtex ${MAIN_TEX_FILE}
+    biber ${MAIN_TEX_FILE}
     pdflatex ${MAIN_TEX_FILE}.tex
     makeindex ${MAIN_TEX_FILE}
     pdflatex ${MAIN_TEX_FILE}.tex


### PR DESCRIPTION
The repository now uses biblatex instead of bibtex. This commit updates the build process to use `biber` instead of `bibtex`. The change is applied to the GitHub Actions workflow for releases and the local `build.sh` script.