### PR TITLE
Fix LaTeX package option clash for newtxmath

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,6 @@
 \usepackage[T1]{fontenc}
 \usepackage{newtxtext}   % text font
 \usepackage{amsmath}     % math environments, aligned, cases, etc.
-\usepackage{newtxmath}   % math font (includes AMS symbols)
 \usepackage{xparse}
 \usepackage{graphicx}
 \usepackage{adjustbox}
@@ -55,10 +54,9 @@
 \usepackage{xspace}
 \usepackage{parskip} % For space between paragraphs instead of indentation
 \usepackage[sb]{libertine}
-\usepackage[libertine]{newtxmath}
+\usepackage[libertine]{newtxmath} % math font (includes AMS symbols)
 \usepackage[final]{microtype}
 \usepackage[scaled]{inconsolata}
-\usepackage{microtype}
 % \usepackage[hyphens]{url}
 
 \emergencystretch=3em           % extra slack for bad lines


### PR DESCRIPTION
## Summary
- remove the duplicate `newtxmath` package load so LaTeX no longer raises an option clash
- drop the redundant second `microtype` inclusion to keep the preamble consistent

## Testing
- `bash build.sh --docker` *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d983109c833381590e946b88e2ba