### PR TITLE
Fix LaTeX package clash for newtxmath

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,6 @@
 \usepackage[T1]{fontenc}
 \usepackage{newtxtext}   % text font
 \usepackage{amsmath}     % math environments, aligned, cases, etc.
-\usepackage{newtxmath}   % math font (includes AMS symbols)
 \usepackage{xparse}
 \usepackage{graphicx}
 \usepackage{adjustbox}


### PR DESCRIPTION
## Summary
- remove the duplicate `newtxmath` package import so the libertine configuration no longer raises an option clash during compilation

## Testing
- `bash build.sh --docker` *(fails: `docker: command not found` in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d983109c833381590e946b88e2ba