### PR TITLE
Fix LaTeX font package clash

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -4,9 +4,7 @@
 \documentclass{ut-thesis}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
-\usepackage{newtxtext}   % text font
 \usepackage{amsmath}     % math environments, aligned, cases, etc.
-\usepackage{newtxmath}   % math font (includes AMS symbols)
 \usepackage{xparse}
 \usepackage{graphicx}
 \usepackage{adjustbox}


### PR DESCRIPTION
## Summary
- remove the extra `newtxtext`/`newtxmath` package declarations so the Libertine math configuration loads without an option clash

## Testing
- `bash build.sh --docker` *(fails: `docker: command not found` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d983109c833381590e946b88e2ba