### PR TITLE
Fix missing semibold shape for Inconsolata

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -66,6 +66,12 @@
 
 % Use semibold instead of bold extended to reduce heaviness of bold text
 \renewcommand{\bfdefault}{sb}
+% Inconsolata (zi4) does not provide a semibold weight; substitute the medium
+% weight instead so listings that request bold text do not trigger missing font
+% shape errors.
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/m/n}{}
+\DeclareFontShape{T1}{zi4}{sb}{it}{<->ssub*zi4/m/it}{}
+\DeclareFontShape{T1}{zi4}{sb}{sl}{<->ssub*zi4/m/sl}{}
 
 \usepackage{etoolbox}
 


### PR DESCRIPTION
## Summary
- substitute the unavailable semibold Inconsolata font shape with the regular weight when bold text is requested
- add substitutions for upright, italic, and slanted shapes to prevent font shape errors in code listings

## Testing
- latexmk -pdf main.tex *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f41d369483339357e42ce78bb047