### PR TITLE
Provide semibold fallback for Inconsolata

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -59,6 +59,12 @@
 \usepackage{microtype}
 % \usepackage[hyphens]{url}
 
+% Provide a semibold typewriter fallback for Inconsolata when sb series is requested
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/m/n}{}
+\DeclareFontShape{T1}{zi4}{sb}{it}{<->ssub*zi4/m/n}{}
+\DeclareFontShape{T1}{zi4}{sb}{sl}{<->ssub*zi4/m/n}{}
+\DeclareFontShape{T1}{zi4}{sb}{sc}{<->ssub*zi4/m/n}{}
+
 \emergencystretch=3em           % extra slack for bad lines
 \frenchspacing                  % uniform interword spacing
 \usepackage{xurl}               % URL line breaks


### PR DESCRIPTION
## Summary
- add font shape substitutions so the document can fall back to Inconsolata's medium weight when a semibold typewriter face is requested
- prevent the “Font shape `T1/zi4/sb/n' undefined” error encountered when compiling the deployment artifacts appendix

## Testing
- latexmk -pdf main.tex *(fails: latexmk not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f41d369483339357e42ce78bb047