### PR TITLE
Fix missing semibold Inconsolata font shape

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -59,6 +59,9 @@
 \usepackage{microtype}
 % \usepackage[hyphens]{url}
 
+% Provide a semibold variant for Inconsolata when requested by \bfseries
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/b/n}{}
+
 \emergencystretch=3em           % extra slack for bad lines
 \frenchspacing                  % uniform interword spacing
 \usepackage{xurl}               % URL line breaks


### PR DESCRIPTION
## Summary
- add a font shape substitution so semibold requests for Inconsolata fall back to the bold face
- prevents the `Font shape \\`T1/zi4/sb/n' undefined` error when listings apply `\bfseries`

## Testing
- bash build.sh *(fails: tlmgr user mode not initialized in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f41d369483339357e42ce78bb047