### PR TITLE
Fix missing semibold font shape for Inconsolata

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -59,6 +59,14 @@
 \usepackage{microtype}
 % \usepackage[hyphens]{url}
 
+% Provide semibold shapes for the Inconsolata typewriter font used in listings.
+% Without these declarations, enabling semibold as the default bold weight causes
+% LaTeX to raise "Font shape `T1/zi4/sb/n' undefined" when \ttfamily text is
+% emboldened (e.g., for keywords inside listings).
+\makeatletter
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/b/n}{}
+\makeatother
+
 \emergencystretch=3em           % extra slack for bad lines
 \frenchspacing                  % uniform interword spacing
 \usepackage{xurl}               % URL line breaks


### PR DESCRIPTION
## Summary
- add a semibold font shape alias for the Inconsolata typewriter family used in listings
- prevent LaTeX from raising the `T1/zi4/sb/n` undefined font shape error when keywords are bolded

## Testing
- latexmk -pdf -quiet main.tex *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f41d369483339357e42ce78bb047