### PR TITLE
Fix Inconsolata semibold fallback

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -67,6 +67,11 @@
 % Use semibold instead of bold extended to reduce heaviness of bold text
 \renewcommand{\bfdefault}{sb}
 
+% Inconsolata does not provide a dedicated semibold shape, so fall back to bold
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/b/n}{}
+\DeclareFontShape{T1}{zi4}{sb}{it}{<->ssub*zi4/b/it}{}
+\DeclareFontShape{T1}{zi4}{sb}{sl}{<->ssub*zi4/b/sl}{}
+
 \usepackage{etoolbox}
 
 \newcommand{\sysname}{\textit{MIBot}\xspace}


### PR DESCRIPTION
## Summary
- map the semibold font shape for Inconsolata to the available bold shapes so listings can render when semibold is the default

## Testing
- `pdflatex -interaction=nonstopmode main.tex` *(fails: missing algorithm.sty in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad07ef1d08333803b46cca90fa712