### PR TITLE
Fix typewriter bold font fallback

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -66,6 +66,7 @@
 
 % Use semibold instead of bold extended to reduce heaviness of bold text
 \renewcommand{\bfdefault}{sb}
+\DeclareFontSeriesDefault[tt]{bf}{b}
 
 \usepackage{etoolbox}
 


### PR DESCRIPTION
## Summary
- ensure the bold font series for the typewriter family falls back to an available weight to avoid missing font shape errors when compiling appendices

## Testing
- latexmk -pdf -interaction=nonstopmode main.tex *(fails: missing algorithm.sty in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad07ef1d08333803b46cca90fa712