### PR TITLE
Fix typewriter bold font fallback

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -66,6 +66,8 @@
 
 % Use semibold instead of bold extended to reduce heaviness of bold text
 \renewcommand{\bfdefault}{sb}
+% Inconsolata lacks a semibold series, so keep bold extended for typewriter fonts
+\DeclareFontSeriesDefault[\ttdefault]{bf}{bx}
 
 \usepackage{etoolbox}
 


### PR DESCRIPTION
## Summary
- ensure that typewriter fonts continue to use the bold extended series when semibold is selected
- prevent the listings environments from requesting an undefined semibold Inconsolata shape

## Testing
- latexmk -pdf main.tex *(fails: missing dependency algorithm.sty in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad07ef1d08333803b46cca90fa712