### PR TITLE
Fix missing semibold Inconsolata font shape

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -66,6 +66,9 @@
 
 % Use semibold instead of bold extended to reduce heaviness of bold text
 \renewcommand{\bfdefault}{sb}
+% The inconsolata typewriter font (family zi4) does not provide a semibold shape,
+% so emulate it by falling back to the medium weight when sb is requested.
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/m/n}{}
 
 \usepackage{etoolbox}
 


### PR DESCRIPTION
## Summary
- declare a semibold shape fallback for the Inconsolata typewriter font so listings can use bold text without errors

## Testing
- bash build.sh (fails: tlmgr user mode not initialized on container)

------
https://chatgpt.com/codex/tasks/task_e_68dcaac23e548333b0acae4fed0bc5c9