### PR TITLE
Fix missing semibold font shape for Inconsolata listings

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -66,6 +66,9 @@
 
 % Use semibold instead of bold extended to reduce heaviness of bold text
 \renewcommand{\bfdefault}{sb}
+% Inconsolata (zi4) lacks a semibold series; map it to the available bold face.
+\DeclareFontShape{T1}{zi4}{sb}{n}{<->ssub*zi4/bx/n}{}
+\DeclareFontShape{T1}{zi4}{sb}{sl}{<->ssub*zi4/bx/sl}{}
 
 \usepackage{etoolbox}
 


### PR DESCRIPTION
## Summary
- map the Inconsolata semibold series to the available bold shapes to avoid font shape errors when typesetting listings

## Testing
- `bash build.sh` *(fails: tlmgr user mode not initialized on Debian image)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaac23e548333b0acae4fed0bc5c9